### PR TITLE
Fix: Persist auth state after refresh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react-hot-toast": "^2.5.2",
         "react-redux": "^9.2.0",
         "react-router-dom": "^7.4.1",
+        "redux-persist": "^6.0.0",
         "yup": "^1.6.1"
       },
       "devDependencies": {
@@ -3782,6 +3783,15 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
       "license": "MIT"
+    },
+    "node_modules/redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": ">4.0.0"
+      }
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-hot-toast": "^2.5.2",
     "react-redux": "^9.2.0",
     "react-router-dom": "^7.4.1",
+    "redux-persist": "^6.0.0",
     "yup": "^1.6.1"
   },
   "devDependencies": {

--- a/src/API/StudentPanel/editUserInfo.jsx
+++ b/src/API/StudentPanel/editUserInfo.jsx
@@ -1,0 +1,15 @@
+import axois from "../ApiConfig";
+
+export const editUserInfo = async (formData) => {
+  try {
+    const result = await axois.put("SharePanel/UpdateProfileInfo", formData, {
+      headers: {
+        "Content-Type": undefined,
+      },
+    });
+
+    return result.data;
+  } catch (error) {
+    console.error("Validation Error:", error?.response?.data);
+  }
+};

--- a/src/API/StudentPanel/form-data.jsx
+++ b/src/API/StudentPanel/form-data.jsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 const OnSetFormData = (value) => {
   const formData = new FormData();
   const keys = Object.keys(value);
@@ -10,9 +8,6 @@ const OnSetFormData = (value) => {
   });
 
   return formData;
-  
 };
-
-
 
 export default OnSetFormData;

--- a/src/API/StudentPanel/form-data.jsx
+++ b/src/API/StudentPanel/form-data.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+const OnSetFormData = (value) => {
+  const formData = new FormData();
+  const keys = Object.keys(value);
+
+  keys.forEach((key) => {
+    const items = value[key];
+    formData.append(key, items);
+  });
+
+  return formData;
+  
+};
+
+
+
+export default OnSetFormData;

--- a/src/API/StudentPanel/getUserInfo.jsx
+++ b/src/API/StudentPanel/getUserInfo.jsx
@@ -1,0 +1,10 @@
+import axois from "../ApiConfig";
+
+export const getUserInfo = async () => {
+  try {
+    const result = await axois.get("/SharePanel/GetProfileInfo");
+    return result.data;
+  } catch (error) {
+    console.error("Error fetching data ...", error);
+  }
+};

--- a/src/App/Store/Store.jsx
+++ b/src/App/Store/Store.jsx
@@ -1,8 +1,23 @@
 import { configureStore } from "@reduxjs/toolkit";
 import authReducer from "../../Components/Features/Auth/AuthSlice";
+import storage from "redux-persist/lib/storage";
+import { persistReducer, persistStore } from "redux-persist";
+import { combineReducers } from "redux";
+
+const persistConfig = {
+  key: "root",
+  storage,
+  whitelist: ["auth"],
+};
+
+const rootReducer = combineReducers({
+  auth: authReducer,
+});
+
+const persistedReducer = persistReducer(persistConfig, rootReducer);
 
 export const Store = configureStore({
-  reducer: {
-    auth: authReducer,
-  },
+  reducer: persistedReducer,
 });
+
+export const persistor = persistStore(Store);

--- a/src/Components/Common/CoursesCard/CoursesCard.jsx
+++ b/src/Components/Common/CoursesCard/CoursesCard.jsx
@@ -1,0 +1,20 @@
+import axios from "../../../API/ApiConfig";
+
+export const CoursesCard = async () => {
+  try {
+    const res = await axios.get(
+      "/Home/GetCoursesWithPagination?PageNumber=3&SortingCol=Active&SortType=DESC&TechCount=0",
+      {
+        headers: {
+          "Content-Type": undefined,
+        },
+      }
+    );
+    console.log(res.data);
+    return res.data;
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+export default CoursesCard;

--- a/src/Components/Common/Navbar/Darkmode&Notif.jsx
+++ b/src/Components/Common/Navbar/Darkmode&Notif.jsx
@@ -4,7 +4,7 @@ import notification from "../../../assets/Navbar/notification-02.svg";
 
 const DarkmodeNotif = () => {
   return (
-    <div className="h-full flex items-center">
+    <div className="h-full flex items-center gap-1">
       <div className="w-14 h-full border rounded-full flex items-center justify-center">
         <img src={notification} alt="notification" />
       </div>

--- a/src/Components/Common/Navbar/Darkmode&Notif.jsx
+++ b/src/Components/Common/Navbar/Darkmode&Notif.jsx
@@ -1,14 +1,13 @@
-import React from "react";
 import darkIcon from "../../../assets/Navbar/Vector.svg";
 import notification from "../../../assets/Navbar/notification-02.svg";
 
 const DarkmodeNotif = () => {
   return (
     <div className="h-full flex items-center gap-1">
-      <div className="w-14 h-full border rounded-full flex items-center justify-center">
+      <div className="w-14 h-14 border rounded-full flex items-center justify-center">
         <img src={notification} alt="notification" />
       </div>
-      <div className="w-14 h-full border rounded-full bgblack flex items-center justify-center">
+      <div className="w-14 h-14 border rounded-full bgblack flex items-center justify-center">
         <img src={darkIcon} alt="darkIcon" />
       </div>
     </div>

--- a/src/Components/Common/Navbar/Menu.jsx
+++ b/src/Components/Common/Navbar/Menu.jsx
@@ -7,12 +7,11 @@ const Menu = () => {
 
   return (
     <div className="h-full w-4/12 bgblack rounded-[56px] whitetext flex items-center justify-center gap-7 ml-24">
-      <span>خانه</span>
-      <span>دوره ها </span>
+      <NavLink to='/'>خانه</NavLink>
+      <NavLink to="/courses">دوره ها </NavLink>
       <span>بلاگ ها</span>
       <span>درباره ما</span>
-      {
-      token ? (
+      {token ? (
         <NavLink to="/panel" className="bgblue p-2 rounded-3xl whitetext">
           پنل کاربری
         </NavLink>
@@ -20,10 +19,8 @@ const Menu = () => {
         <NavLink to="/login" className="bgblue p-2 rounded-3xl whitetext">
           ثبت نام یا ورود
         </NavLink>
-      ) 
-      }
+      )}
     </div>
-    
   );
 };
 

--- a/src/Components/Pages/Courses/CardLayout.jsx
+++ b/src/Components/Pages/Courses/CardLayout.jsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from "react";
+import CoursesCard from "../../Common/CoursesCard/CoursesCard";
+
+const CardLayout = () => {
+  const [course, setCourse] = useState([]);
+
+  const getCourse = async () => {
+    try {
+      const callApi = await CoursesCard();
+      setCourse(callApi?.courseFilterDtos || []);
+      console.log(callApi);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+  useEffect(() => {
+    getCourse();
+  }, []);
+
+  console.log(course);
+
+  return (
+    <div className="w-9/12 flexbetween flex-wrap">
+      {course?.map((value) => (
+        <div key={value.courseId} className="w-[300px] h-[350px] mt-10">
+          <img
+            src={value.tumbImageAddress}
+            alt="pic"
+            className="w-full h-3/4 rounded-[32px]"
+          />
+          <span className="text-xl font-semibold h-5 border mt-3">{value.title}</span>
+          <div className="flexbetween">
+            <span>{value.teacherName}</span>
+            <span>{value.cost}</span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default CardLayout;

--- a/src/Components/Pages/Courses/Courses.jsx
+++ b/src/Components/Pages/Courses/Courses.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import CoursesTop from './CoursesTop'
+import CoursesSort from './CoursesSort'
+import CoursesFilter from './CoursesFilter'
+import CardLayout from './CardLayout'
+
+const Courses = () => {
+  return (
+    <div>
+        <CoursesTop />
+        <CoursesSort />
+        <div className='flexaround gap-24 mt-5'>
+            <CoursesFilter />
+            <CardLayout />
+        </div>
+    </div>
+  )
+}
+
+export default Courses

--- a/src/Components/Pages/Courses/CoursesFilter.jsx
+++ b/src/Components/Pages/Courses/CoursesFilter.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const CoursesFilter = () => {
+  return (
+    <div className='w-3/12 border'>CoursesFilter</div>
+  )
+}
+
+export default CoursesFilter

--- a/src/Components/Pages/Courses/CoursesSort.jsx
+++ b/src/Components/Pages/Courses/CoursesSort.jsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+const CoursesSort = () => {
+  return (
+    <div className="w-2/5 mx-auto h-9 basicflex gap-5 justify-start">
+      <span className="text-lg font-semibold">ترتیب</span>
+      <button className="h-full w-1/6 rounded-full border border-[#2F2F2F]">
+        جدیدترین
+      </button>
+      <button className="h-full w-1/6 rounded-full border border-[#2F2F2F]">
+        محبوب ترین
+      </button>
+      <button className="h-full w-1/6 rounded-full border border-[#2F2F2F]">
+        گران ترین
+      </button>
+      <button className="h-full w-1/6 rounded-full border border-[#2F2F2F]">
+        ارزان ترین
+      </button>
+    </div>
+  );
+};
+
+export default CoursesSort;

--- a/src/Components/Pages/Courses/CoursesTop.jsx
+++ b/src/Components/Pages/Courses/CoursesTop.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+const CoursesTop = () => {
+  return (
+    <div className='basiccolflex h-[250px]'>
+        <span className='font-bold text-4xl'>شروع ماجراجویی جدید</span>
+        <span className='font-medium text-lg mt-5 w-72 text-center'>یک شروع قوی برای یادگیری یک مسئله جدید میتونه تو پیشرفت کمکت کنه</span>
+    </div>
+  )
+}
+
+export default CoursesTop

--- a/src/Components/StudentPanel/Dashboard.jsx
+++ b/src/Components/StudentPanel/Dashboard.jsx
@@ -1,7 +1,19 @@
+import { useEffect, useState } from "react";
 import { useOutletContext } from "react-router-dom";
 
 const Dashboard = () => {
   const { userInfo } = useOutletContext();
+
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (userInfo) {
+      setLoading(false);
+    }
+  }, [userInfo]);
+
+  if (loading) return <div>Loading...</div>;
+
   return (
     <div className="whitetext flex flex-col gap-3">
       <span>fname : {userInfo.fName}</span>

--- a/src/Components/StudentPanel/Dashboard.jsx
+++ b/src/Components/StudentPanel/Dashboard.jsx
@@ -1,13 +1,14 @@
-import React from "react";
+import { useOutletContext } from "react-router-dom";
 
 const Dashboard = () => {
+  const { userInfo } = useOutletContext();
   return (
     <div className="whitetext flex flex-col gap-3">
-      <span>fname</span>
-      <span>lname</span>
-      <span>number</span>
-      <span>user about</span>
-      <span>gender</span>
+      <span>fname : {userInfo.fName}</span>
+      <span>lname : {userInfo.lName}</span>
+      <span>number : {userInfo.phoneNumber}</span>
+      <span>user about : {userInfo.userAbout}</span>
+      <span>gender : {userInfo.gender ? "مرد" : "زن"}</span>
     </div>
   );
 };

--- a/src/Components/StudentPanel/Dashboard.jsx
+++ b/src/Components/StudentPanel/Dashboard.jsx
@@ -1,9 +1,15 @@
-import React from 'react'
+import React from "react";
 
 const Dashboard = () => {
   return (
-    <div>Dashboard</div>
-  )
-}
+    <div className="whitetext flex flex-col gap-3">
+      <span>fname</span>
+      <span>lname</span>
+      <span>number</span>
+      <span>user about</span>
+      <span>gender</span>
+    </div>
+  );
+};
 
-export default Dashboard
+export default Dashboard;

--- a/src/Components/StudentPanel/EditProfile.jsx
+++ b/src/Components/StudentPanel/EditProfile.jsx
@@ -1,9 +1,71 @@
-import React from 'react'
+import { Field, Form, Formik } from "formik";
+import { useEffect, useState } from "react";
+import { getUserInfo } from "../../API/StudentPanel/getUserInfo";
+import { editUserInfo } from "../../API/StudentPanel/editUserInfo";
+import OnSetFormData from "../../API/StudentPanel/form-data";
 
 const EditProfile = () => {
-  return (
-    <div>EditProfile</div>
-  )
-}
+  const [initialValues, setInitialValues] = useState(null);
 
-export default EditProfile
+  const GetProfileInfo = async () => {
+    try {
+      const callApi = await getUserInfo();
+      const data = {
+        FName: callApi?.FName,
+        LName: callApi?.LName,
+        UserAbout: callApi?.UserAbout,
+        HomeAdderess: callApi?.HomeAdderess,
+        NationalCode: callApi?.NationalCode,
+        BirthDay: callApi?.BirthDay,
+      };
+      setInitialValues(data);
+    } catch (error) {
+      console.error("error", error);
+    }
+  };
+
+  const onSubmit = async (value) => {
+    try {
+      const res = OnSetFormData(value);
+      const callApi = await editUserInfo(res);
+      console.log(callApi);
+      // for (let [key, value] of res.entries()) {
+      //   console.log(`${key}: ${value}`);
+      // }
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  useEffect(() => {
+    GetProfileInfo();
+  }, []);
+
+  return (
+    <div>
+      <Formik
+        initialValues={initialValues}
+        onSubmit={onSubmit}
+        enableReinitialize
+      >
+        <Form className="flex flex-col w-4/12 gap-2 items-center">
+          <label htmlFor="FName">نام</label>
+          <Field id="FName" type="text" name="FName"></Field>
+          <label htmlFor="LName">نام خانوادگی</label>
+          <Field id="LName" type="text" name="LName"></Field>
+          <label htmlFor="UserAbout">درباره من</label>
+          <Field id="UserAbout" type="text" name="UserAbout"></Field>
+          <label htmlFor="NationalCode">کدملی</label>
+          <Field id="NationalCode" type="text" name="NationalCode"></Field>
+          <label htmlFor="BirthDay">تاریخ تولد</label>
+          <Field id="BirthDay" type="text" name="BirthDay"></Field>
+          <label htmlFor="HomeAdderess">محل سکونت</label>
+          <Field id="HomeAdderess" type="text" name="HomeAdderess"></Field>
+          <button type="submit">Save Changes</button>
+        </Form>
+      </Formik>
+    </div>
+  );
+};
+
+export default EditProfile;

--- a/src/Components/StudentPanel/PanelNavbar.jsx
+++ b/src/Components/StudentPanel/PanelNavbar.jsx
@@ -1,0 +1,23 @@
+import React from "react";
+import Logo from "../Common/Navbar/Logo";
+import DarkmodeNotif from "../Common/Navbar/Darkmode&Notif";
+import PanelTopMenu from "./PanelTopMenu";
+
+const PanelNavbar = () => {
+  return (
+    <div className="h-14 w-full flex justify-between">
+      <Logo />
+      <div className="flex gap-3 whitetext items-center">
+        <img src="" alt="pic" className="w-12 h-12 border rounded-full" />
+        <div className="flex flex-col">
+          <span>سلام سینا</span>
+          <span>دانشجو</span>
+        </div>
+      </div>
+      <PanelTopMenu />
+      <DarkmodeNotif />
+    </div>
+  );
+};
+
+export default PanelNavbar;

--- a/src/Components/StudentPanel/PanelNavbar.jsx
+++ b/src/Components/StudentPanel/PanelNavbar.jsx
@@ -1,11 +1,10 @@
-import React from "react";
 import Logo from "../Common/Navbar/Logo";
 import DarkmodeNotif from "../Common/Navbar/Darkmode&Notif";
 import PanelTopMenu from "./PanelTopMenu";
 
 const PanelNavbar = ({ userInfo }) => {
   return (
-    <div className="h-14 w-full flex justify-between">
+    <div className="h-14 flex justify-between mx-5 pt-2">
       <Logo />
       <div className="flex gap-3 whitetext items-center">
         <img src={userInfo.userImage} alt="pic" className="w-12 h-12 border rounded-full" />

--- a/src/Components/StudentPanel/PanelNavbar.jsx
+++ b/src/Components/StudentPanel/PanelNavbar.jsx
@@ -3,14 +3,14 @@ import Logo from "../Common/Navbar/Logo";
 import DarkmodeNotif from "../Common/Navbar/Darkmode&Notif";
 import PanelTopMenu from "./PanelTopMenu";
 
-const PanelNavbar = () => {
+const PanelNavbar = ({ userInfo }) => {
   return (
     <div className="h-14 w-full flex justify-between">
       <Logo />
       <div className="flex gap-3 whitetext items-center">
-        <img src="" alt="pic" className="w-12 h-12 border rounded-full" />
+        <img src={userInfo.userImage} alt="pic" className="w-12 h-12 border rounded-full" />
         <div className="flex flex-col">
-          <span>سلام سینا</span>
+          <span>سلام {userInfo.fName}</span>
           <span>دانشجو</span>
         </div>
       </div>

--- a/src/Components/StudentPanel/PanelSideMenu.jsx
+++ b/src/Components/StudentPanel/PanelSideMenu.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { NavLink } from 'react-router-dom'
+
+const PanelSideMenu = () => {
+  return (
+    <div className='border border-red-500 h-[660px] w-[290px] flex flex-col whitetext gap-3'>
+        <NavLink to='/panel'>داشبورد</NavLink>
+        <NavLink to='/panel/profile'>پروفایل</NavLink>
+    </div>
+  )
+}
+
+export default PanelSideMenu

--- a/src/Components/StudentPanel/PanelTopMenu.jsx
+++ b/src/Components/StudentPanel/PanelTopMenu.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { NavLink } from "react-router-dom";
+
+const PanelTopMenu = () => {
+  return (
+    <div className="h-full w-4/12 whitetext flex items-center justify-center gap-7 ml-24">
+      <NavLink to="/">صفحه اصلی</NavLink>
+      <span>گزارش</span>
+      <span>ارتباط با ما</span>
+    </div>
+  );
+};
+
+export default PanelTopMenu;

--- a/src/Components/StudentPanel/Profile/EditProfile.jsx
+++ b/src/Components/StudentPanel/Profile/EditProfile.jsx
@@ -1,8 +1,8 @@
 import { Field, Form, Formik } from "formik";
 import { useEffect, useState } from "react";
-import { getUserInfo } from "../../API/StudentPanel/getUserInfo";
-import { editUserInfo } from "../../API/StudentPanel/editUserInfo";
-import OnSetFormData from "../../API/StudentPanel/form-data";
+import { getUserInfo } from "../../../API/StudentPanel/getUserInfo";
+import { editUserInfo } from "../../../API/StudentPanel/editUserInfo";
+import OnSetFormData from "../../../API/StudentPanel/form-data";
 
 const EditProfile = () => {
   const [initialValues, setInitialValues] = useState(null);

--- a/src/Components/StudentPanel/Profile/EditProfile.jsx
+++ b/src/Components/StudentPanel/Profile/EditProfile.jsx
@@ -11,12 +11,13 @@ const EditProfile = () => {
     try {
       const callApi = await getUserInfo();
       const data = {
-        FName: callApi?.FName,
-        LName: callApi?.LName,
-        UserAbout: callApi?.UserAbout,
-        HomeAdderess: callApi?.HomeAdderess,
-        NationalCode: callApi?.NationalCode,
-        BirthDay: callApi?.BirthDay,
+        FName: callApi?.fName,
+        LName: callApi?.lName,
+        UserAbout: callApi?.userAbout,
+        HomeAdderess: callApi?.homeAdderess,
+        NationalCode: callApi?.nationalCode,
+        BirthDay: callApi?.birthDay,
+        Gender: callApi?.gender,
       };
       setInitialValues(data);
     } catch (error) {
@@ -61,6 +62,8 @@ const EditProfile = () => {
           <Field id="BirthDay" type="text" name="BirthDay"></Field>
           <label htmlFor="HomeAdderess">محل سکونت</label>
           <Field id="HomeAdderess" type="text" name="HomeAdderess"></Field>
+          <label htmlFor="Gender">جنسیت</label>
+          <Field id="Gender" type="text" name="Gender"></Field>
           <button type="submit">Save Changes</button>
         </Form>
       </Formik>

--- a/src/Components/StudentPanel/StudentPanel.jsx
+++ b/src/Components/StudentPanel/StudentPanel.jsx
@@ -1,8 +1,7 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Outlet } from "react-router-dom";
 import PanelNavbar from "./PanelNavbar";
 import PanelSideMenu from "./PanelSideMenu";
-import Dashboard from "./Dashboard";
 import axios from "../../API/ApiConfig";
 
 const StudentPanel = () => {
@@ -21,12 +20,14 @@ const StudentPanel = () => {
     user();
   }, []);
   return (
-    <div className="bg-[#242424] h-screen">
-      <PanelNavbar userInfo={userInfo}/>
-      <div className="flex gap-10 m-5">
-        <PanelSideMenu />
-        <div className="border border-yellow-500 w-4/5">
-          <Outlet context={{ userInfo }} />
+    <div className="bg-[#242424] mx-auto h-screen">
+      <div className="w-[1440px]">
+        <PanelNavbar userInfo={userInfo} />
+        <div className="flex gap-10 m-5">
+          <PanelSideMenu />
+          <div className="border border-yellow-500 w-4/5">
+            <Outlet context={{ userInfo }} />
+          </div>
         </div>
       </div>
     </div>

--- a/src/Components/StudentPanel/StudentPanel.jsx
+++ b/src/Components/StudentPanel/StudentPanel.jsx
@@ -1,12 +1,19 @@
 import React from "react";
-import { NavLink, Outlet } from "react-router-dom";
+import { Outlet } from "react-router-dom";
+import PanelNavbar from "./PanelNavbar";
+import PanelSideMenu from "./PanelSideMenu";
+import Dashboard from "./Dashboard";
 
 const StudentPanel = () => {
   return (
     <div className="bg-[#242424] h-screen">
-      <NavLink to="/panel">dashboard</NavLink>
-      <NavLink to="/panel/profile">profile</NavLink>
-      <Outlet />
+      <PanelNavbar />
+      <div className="flex gap-10 m-5">
+        <PanelSideMenu />
+        <div className="border border-yellow-500 w-4/5">
+          <Outlet />
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/Components/StudentPanel/StudentPanel.jsx
+++ b/src/Components/StudentPanel/StudentPanel.jsx
@@ -1,17 +1,32 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Outlet } from "react-router-dom";
 import PanelNavbar from "./PanelNavbar";
 import PanelSideMenu from "./PanelSideMenu";
 import Dashboard from "./Dashboard";
+import axios from "../../API/ApiConfig";
 
 const StudentPanel = () => {
+  const [userInfo, setUserInfo] = useState("");
+
+  const user = async () => {
+    try {
+      const res = await axios.get("/SharePanel/GetProfileInfo");
+      setUserInfo(res.data);
+    } catch {
+      console.log("data error ...");
+    }
+  };
+
+  useEffect(() => {
+    user();
+  }, []);
   return (
     <div className="bg-[#242424] h-screen">
-      <PanelNavbar />
+      <PanelNavbar userInfo={userInfo}/>
       <div className="flex gap-10 m-5">
         <PanelSideMenu />
         <div className="border border-yellow-500 w-4/5">
-          <Outlet />
+          <Outlet context={{ userInfo }} />
         </div>
       </div>
     </div>

--- a/src/Config/Router/common.route.jsx
+++ b/src/Config/Router/common.route.jsx
@@ -6,13 +6,19 @@ import Notfound from "../../Components/Pages/404/Notfound";
 import PrivateRoute from "./privateRoute";
 import StudentPanel from "../../Components/StudentPanel/StudentPanel";
 import Dashboard from "../../Components/StudentPanel/Dashboard";
-import EditProfile from "../../Components/StudentPanel/EditProfile";
+import EditProfile from "../../Components/StudentPanel/Profile/EditProfile";
+import Courses from "../../Components/Pages/Courses/Courses";
 
 export const commonRoute = [
   {
     path: "/",
     element: <MainLayout />,
-    children: [],
+    children: [
+      {
+        path: "/courses",
+        element: <Courses />,
+      },
+    ],
   },
   {
     path: "/login",

--- a/src/Config/Router/common.route.jsx
+++ b/src/Config/Router/common.route.jsx
@@ -37,15 +37,15 @@ export const commonRoute = [
         <StudentPanel />
       </PrivateRoute>
     ),
-    children:[
+    children: [
       {
         index: true,
-        element: <Dashboard />
+        element: <Dashboard />,
       },
       {
         path: "profile",
-        element: <EditProfile />
-      }
-    ]
+        element: <EditProfile />,
+      },
+    ],
   },
 ];

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,12 +4,18 @@ import App from "./App/App";
 import "./assets/Fonts/css/style.css";
 import "./Style/index.css";
 import { Provider } from "react-redux";
-import { Store } from "./App/Store/Store";
+import { persistor, Store } from "./App/Store/Store";
+import { PersistGate } from "redux-persist/integration/react";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
     <Provider store={Store}>
-      <App />
+      <PersistGate
+        loading={<div>در حال بازیابی اطلاعات...</div>}
+        persistor={persistor}
+      >
+        <App />
+      </PersistGate>
     </Provider>
   </StrictMode>
 );

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,10 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  server: {
+    historyApiFallback: true,
+  },
+});


### PR DESCRIPTION
### What I did:
- Integrated `redux-persist` to keep the `auth` state (token & user info) persistent across page reloads.
- Updated `store.js` to use `persistReducer` and `persistStore`.
- Wrapped the app with `PersistGate` in `index.js` to delay UI rendering until state is rehydrated.
- Ensured that the user remains logged in even after refreshing the page.

### Why it matters:
Previously, refreshing the page would reset the Redux state and redirect the user to the landing page. This update prevents that issue and keeps the user authenticated as long as the token exists in localStorage.

### Next Steps (optional):
- Consider persisting only the token and re-fetching user info from API for better security.


### تغییرات انجام‌شده:
- اضافه کردن `redux-persist` برای نگه‌داشتن وضعیت احراز هویت (توکن و اطلاعات کاربر) بعد از رفرش صفحه
- به‌روزرسانی `store.js` برای اعمال `persistReducer` و `persistStore`
- استفاده از `PersistGate` برای هماهنگی رندر شدن اپ بعد از بازیابی اطلاعات
- جلوگیری از خروج کاربر از پنل پس از رفرش صفحه

### دلیل اهمیت این تغییر:
قبلاً با رفرش صفحه، وضعیت Redux ریست می‌شد و کاربر به لندینگ برمی‌گشت. این تغییر باعث می‌شود تا کاربر در سیستم لاگین باقی بماند تا زمانی که توکن معتبر در localStorage وجود دارد.
